### PR TITLE
Add roadmap

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,7 +19,8 @@
         <ul class="page-link">
           <li><a href="{{ "/" | prepend: site.baseurl }}">Welcome</a></li>
           <li><a href="{{ "/strategy" | prepend: site.baseurl }}">Strategy</a></li>
-          <li><a href="{{ "/overview" | prepend: site.baseurl }}">Overview</a></li>
+          <li><a href="{{ "/roadmap" | prepend: site.baseurl }}">Road Map</a></li>
+          <li><a href="{{ "/overview" | prepend: site.baseurl }}">How It Works</a></li>
           <li><a href="{{ "/contributorshandbook" | prepend: site.baseurl }}">Contributing</a></li>
           <li><a href="{{ "/labelling" | prepend: site.baseurl }}">Labelling</a></li>
         </ul>

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,40 @@
+## Road Map
+
+### 2017 Funded Commitments
+
+Libraries.io is a project of Brave New Software. The project is supported by the following organisations until 1st January 2018:
+
+* [Brave New Software](http://www.bravenewsoftware.org/)
+* [The Alfred P. Sloan Foundation](https://sloan.org/programs/digital-technology)
+* [The Ford Foundation](https://www.fordfoundation.org/work/challenging-inequality/internet-freedom/)
+
+The [supporters repository](https://github.com/librariesio/supporters/issues) contains details of our commitments to our supporters throughout 2017. The main technical goals are:
+
+- Adding support for projects hosted on GitLab and BitBucket
+- Creating parity among the supported package managers
+- Establishing a baseline of metrics to measure against
+- Releasing metric and dependency graph information 
+- Adding external metrics in Libraries.io meta-data
+
+There are also a number of non, developer centered goals. Mainly these are about raising demand for and usage of Libraries.io as a service and as a source of data.
+
+### 2017 Additional Goals
+
+In addition to our funded commitments in 2017 we will prioritise:
+
+- Adding support for projects hosted on SourceForge
+- Adding more guidance for contributors
+- Improving technical documentation
+- Publishing our mission, strategy and philosophy
+
+### 2018 Goals
+
+We have a number of ideas that we are interested in pursuing in 2018:
+
+- Monitoring system-level dependencies
+- Bridging from application to system-level dependencies
+- Federating search facilities to multiple providers
+- Adding code-search facilities
+- Identifying individual contributors with rights to publish updates
+
+We will keep this document updated periodically. Please check our [issue tracker](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Alibrariesio) for more information. 


### PR DESCRIPTION
* add roadmap
* add roadmap to sidebar
* rename ‘overview’ to how it works’ in sidebar

Not going to change the URL as it’s linked to elsewhere.

TODO

- [ ] deprecate wiki

closes #37 