### PR TITLE
Libraries.io strategy update

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We do this by tackling three problems:
 Libraries.io is the place that we attempt to solve the discovery problem for users, we solve the other two at our parent company [Tidelift](https://tidelift.com). If you'd like to know why we think this is the right approach then check out [our strategy](/strategy.md).
 
 ### Who are Tidelift?
-In October 2017 Libraries.io maintainers Andrew Nesbitt and Benjamin Nickolls decided to join a new company focussed on building a sustainable future for open source software. Tidelift launched to the public in February 2017 and continue to support Libraries.io as part of their core philosophy and strategy.  
+In October 2017 Libraries.io maintainers Andrew Nesbitt and Benjamin Nickolls decided to join a new company focussed on building a sustainable future for open source software. Tidelift launched to the public in February 2018 and continue to support Libraries.io as part of their core philosophy and strategy.  
 
 ## Who is Libraries.io For?
 

--- a/README.md
+++ b/README.md
@@ -15,16 +15,29 @@ We do this by tackling three problems:
 
 * Discovery: _Helping developers make faster, more informed decisions about the software that they use._
 * Maintainability: _Helping maintainers understand more about the software they depend upon and the consumers of their software._
-* Sustainability: _Supporting undervalued software by highlighting shortfalls in contribution and funneling support to them._
+* Sustainability: _Supporting undervalued software by providing a scalable and sustainable revenue for maintainers_
 
-If you'd like to know why we think this is the right approach then check out [our strategy](/strategy.md).
+Libraries.io is the place that we attempt to solve the discovery problem for users, we solve the other two at our parent company [Tidelift](https://tidelift.com). If you'd like to know why we think this is the right approach then check out [our strategy](/strategy.md).
+
+### Who are Tidelift?
+In October 2016 Libraries.io maintainers Andrew Nesbitt and Benjamin Nickolls decided to join a new company focussed on building a sustainable future for open source software. Tidelift launched to the public in February 2017 and continue to support Libraries.io as part of their core philosophy and strategy.  
+
+## Who is Libraries.io For?
+
+Libraries.io currently caters for the needs of three groups:
+
+* Google: is hungry for your linked datas so she can serve you up search traffic.
+* Searcher: is a developer with a problem, she is looking for something to help solve it.
+* Extender: has her own ideas. She wants access to the raw data so that she can mash up her own service and offer it to the world.
+
+These groups have been expanded into [personas](/personas.md) for contributors to reference in their work.
 
 ## How Does Libraries.io Work?
 Libraries.io collects data about software and the frameworks, plugins and tools they depend upon which we collectively call libraries.
 
 Everything in Libraries.io begins with [package managers](/packagemanagers.md), on a regular basis background tasks find new or updated libraries from each of those packages managers. Each library is stored as a project alongside any data we can gleam from the package manager. If the package manager provides a link to a hosted revision control service like GitHub then Libraries.io fetches yet more data from there.
 
-Using the data collected we then calculate the [SourceRank](/overview.md#sourcerank), this value is used to index the project in search results. Next we highlight any issues regarding updates, deprecated versions, yanked or deleted libraries, license incompatibilities etc. to maintainers who depend on a given library. Finally we highlight undervalued and under-supported libraries, guiding maintainers toward projects that they could contribute to that would have a direct benefit on their own work.
+Using the data collected we then calculate the [SourceRank](/overview#sourcerank), this value is used to index the project in search results. Next we highlight any issues regarding updates, deprecated versions, yanked or deleted libraries, license incompatibilities etc.
 
 If you'd like an overview of the project, including a description of each of the repositories in the Libraries.io organisation and how they work together then check out our [overview](/overview.md).
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We do this by tackling three problems:
 Libraries.io is the place that we attempt to solve the discovery problem for users, we solve the other two at our parent company [Tidelift](https://tidelift.com). If you'd like to know why we think this is the right approach then check out [our strategy](/strategy.md).
 
 ### Who are Tidelift?
-In October 2016 Libraries.io maintainers Andrew Nesbitt and Benjamin Nickolls decided to join a new company focussed on building a sustainable future for open source software. Tidelift launched to the public in February 2017 and continue to support Libraries.io as part of their core philosophy and strategy.  
+In October 2017 Libraries.io maintainers Andrew Nesbitt and Benjamin Nickolls decided to join a new company focussed on building a sustainable future for open source software. Tidelift launched to the public in February 2017 and continue to support Libraries.io as part of their core philosophy and strategy.  
 
 ## Who is Libraries.io For?
 

--- a/contributing.md
+++ b/contributing.md
@@ -8,7 +8,7 @@ Thanks for considering contributing. These guidelines outline how to contribute 
 
 [What should I know Before I get started?](#what-should-i-know-before-i-get-started)
 * [Code of conduct](#code-of-conduct)
-* [Langauge](#langauge)
+* [Language](#language)
 * [Installation and setup](#setup)
 
 [How can I contribute?](#how-can-i-contribute)
@@ -37,14 +37,16 @@ By outlining our [mission and strategy](/strategy.md) we hope to give you more p
 * Maintainability: _Helping maintainers understand more about the software they depend upon and the consumers of their software._
 * Sustainability: _Supporting undervalued software by highlighting shortfalls in contribution and funneling support to them._
 
+The first of these problems is our foccus for Libraries.io. The other two we are trying to tackle at [Tidelift](https://tidelift.com).
+
 ## Who is Libraries.io For?
 Libraries.io currently caters for the needs of three distinct user groups:
 
 * Google: _is hungry for your linked datas so she can serve you up search traffic_
-* Searcher: _is a developer with a problem, she is looking for something to help solve it._ 
+* Searcher: _is a developer with a problem, she is looking for something to help solve it._
 * Maintainer: _has a project that is used within and/or incorporates open dependencies. She needs to ensure her project(s) are working as expected for users._
 
-These groups have been expanded into [personas](/personas.md) for contributors to reference. 
+These groups have been expanded into [personas](/personas.md) for contributors to reference.
 
 ## What Should I Know Before I Get Started?
 
@@ -69,7 +71,7 @@ The simplest thing that you can do to help us is by filing good bug reports, so 
 #### Before Submitting a Bug Report
 
 * Double-check that the bug is persistent. The site is still in it's infancy and sometimes artifacts may appear and disappear.
-* Double-check the bug hasn't already been reported [on our issue tracker](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Alibrariesio), they *should* be labelled `bug` or `bugsnag`.
+* Double-check the bug hasn't already been reported [on our issue tracker](https://github.com/search?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Alibrariesio), they *should* be labelled `bug` or `bugsnag`.
 
 If something hasn't been raised, you can go ahead and create a new issue using [the template](/issue_template.md). If you'd like to help investigate further or fix the bug just mention it in your issue and check out our [workflow](#workflow).
 
@@ -79,7 +81,7 @@ The next simplest thing you can do to help us is by telling us how we can improv
 
 #### Before Submitting an Enhancement
 
-* Check that the enhancement is not already [in our issue tracker](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Alibrariesio), they should be labelled 'enhancement'.
+* Check that the enhancement is not already [in our issue tracker](https://github.com/search?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Alibrariesio), they should be labelled 'enhancement'.
 
 If there isn't already an issue for feature then go ahead and create a new issue for it using the [template](/issue_template.md). If you'd like to work on the enhancement then just mention it in a comment and check out our [workflow](#workflow).
 
@@ -90,13 +92,12 @@ If you're into this zone then you need to understand a little more about what we
 #### Before Suggesting a Feature
 
 * Check that it aligns with [our strategy](strategy.md) and is specifically not in line with something we have said we will not do (for the moment this is anything to do with ranking *people*).
-* Check that the feature is not already [in our issue tracker](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Alibrariesio), they should be tagged 'feature'.
-* Specifically check that it is not already a [funded commitment](https://github.com/librariesio/supporters/issues).
+* Check that the feature is not already [in our issue tracker](https://github.com/search?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Alibrariesio), they should be tagged 'feature'.
 
 If you're still thinking about that killer feature that no one else is thinking about then *please* create an issue for it using the [template](/issue_template.md).
 
 ### Your First Contribution
-You're in luck! We label issues that are ideal for first time contributors with [`first-pr`](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+user%3Alibrariesio+label%3A%22first-pr%22). For someone who wants something a little more meaty you might find an issue that needs some assistance with [`help wanted`](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+user%3Alibrariesio+label%3A%22help+wanted%22). Next you'll want to read our [workflow](#workflow).
+You're in luck! We label issues that are ideal for first time contributors with [`first-pr`](https://github.com/search?l=&q=is%3Aopen+is%3Aissue+org%3Alibrariesio+label%3Afirst-pr&ref=advsearch&type=Issues&utf8=%E2%9C%93). For someone who wants something a little more meaty you might find an issue that needs some assistance with [`help wanted`](https://github.com/search?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Alibrariesio+label%3A%22help+wanted%22&type=Issues). Next you'll want to read our [workflow](#workflow).
 
 ### Tackling Something Meatier
 
@@ -105,7 +106,7 @@ Tickets are labeled by size, skills required and to indicate workflow. Details c
 To get you started you might want to check out issues concerning [documentation](https://github.com/librariesio/documentation/issues/), [user experience](https://github.com/librariesio/libraries.io/labels/ux), [visual design](https://github.com/librariesio/libraries.io/issues/labels/visual%20design) or perhaps something already [awaiting help](https://github.com/librariesio/libraries.io/labels/help%20wanted). You may find the following useful:
 
 * Our [strategy](/strategy.md) which outlines what our goals are, how we are going to achieve those goals and what we are specifically going to avoid.
-* A [techncial overview](/overview.md) of the components that make up the Libraries.io project and run the [https://libraries.io](https://libraries.io) site.
+* An [overview](/overview.md) of the components that make up the Libraries.io project and run the [https://libraries.io](https://libraries.io) site.
 
 ## How Can I Talk To Other Contributors?
 
@@ -124,7 +125,7 @@ Members are encouraged to openly discuss their work, their lives, share views an
 [Google Hangouts](http://hangouts.google.com) is our preferred tool for video chat. We operate an [open hangout](http://bit.ly/2kWtYak) for anyone to jump into at any time to discuss issues face to face.
 
 ### Regular updates
-Contributors are encouraged to share what they're working on. We do this through daily or weekly updates in the `#general` channel on Slack. Updates should take the format 'currently working on X, expecting to move onto Y, blocked on Z' where x, y and z are issues in our [issue tracker](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Alibrariesio).
+Contributors are encouraged to share what they're working on. We do this through daily or weekly updates in the `#general` channel on Slack. Updates should take the format 'currently working on X, expecting to move onto Y, blocked on Z' where x, y and z are issues in our [issue tracker](https://github.com/search?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Alibrariesio).
 
 Additionally we host an [open hangout](http://bit.ly/2kWtYak) for any contributor to join at *5pm BST/GMT on a Tuesday* to discuss their work, the next week's priorities and to ask questions of other contributors regarding any aspect of the project. Again this is considered a *safe space* in which *there is no such thing as a stupid question*.
 
@@ -143,23 +144,14 @@ We have a Medium account at [@librariesio](https://medium.com/@librariesio) and 
 ## Who Are Libraries.io's Users?
 Libraries.io focusses on the following personas:
 
-### Google 
+### Google
 _Is hungry for linked data so she can serve you up search traffic_
 
-### 'Searcher' 
-_Is a developer with a problem, she is looking for something to help solve it._ 
-
-### 'Producer' 
-_Has a product or products that incorporates some free/open source dependencies. She needs to ensure the product(s) are well maintained, free of vulnerabilities and licence compatible._
-
-### 'Maintainer'
-_Is a developer with a successful free/open source project. She's looking to understand more about those who use her project, attract more contributors and manage their contributions well._
+### 'Searcher'
+_Is a developer with a problem, she is looking for something to help solve it._
 
 ### 'Extender'
 _Has her own ideas. She wants access to the raw data so that she can mash up her own service and offer it to the world._
-
-### 'Overlord'
-_Has a vast empire of people, products and projects. Some of which she publishes as open source, some are proprietary. She wants to ensure that her policies regarding the use of dependencies are adhered to and that her team are as efficient as possible._
 
 ## Workflow
 In general we use [GitHub](https://help.github.com/) and [Git](https://git-scm.com/docs/gittutorial) to support our workflow. If you are unfamiliar with those tools then you should check them out until you feel you have a basic understanding of GitHub and a working understanding of Git. Specifically you should understand how forking, branching, committing, PRing and merging works.
@@ -198,5 +190,6 @@ We appreciate that it may be difficult to offer constructive criticism, but it i
 
 #### Merging
 As we keep the `master` branch in a permanent state of 'deployment ready' once-merged your contribution will be live on the next deployment.
+
 #### Deploying
 Any member of the [deployers](https://github.com/orgs/librariesio/teams/deployers) team are able to redeploy the site. If you require a deployment then you might find one of them in our `#general` [chat channel on Slack](slack.libraries.io).

--- a/contributorshandbook.md
+++ b/contributorshandbook.md
@@ -37,6 +37,8 @@ By outlining our [mission and strategy](/strategy.md) we hope to give you more p
 * Maintainability: _Helping maintainers understand more about the software they depend upon and the consumers of their software._
 * Sustainability: _Supporting undervalued software by highlighting shortfalls in contribution and funneling support to them._
 
+The first of these problems is our foccus for Libraries.io. The other two we are trying to tackle at [Tidelift](https://tidelift.com).
+
 ## Who is Libraries.io For?
 Libraries.io currently caters for the needs of three distinct user groups:
 
@@ -91,7 +93,6 @@ If you're into this zone then you need to understand a little more about what we
 
 * Check that it aligns with [our strategy](strategy.md) and is specifically not in line with something we have said we will not do (for the moment this is anything to do with ranking *people*).
 * Check that the feature is not already [in our issue tracker](https://github.com/search?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Alibrariesio), they should be tagged 'feature'.
-* Specifically check that it is not already a [funded commitment](https://github.com/librariesio/supporters/issues).
 
 If you're still thinking about that killer feature that no one else is thinking about then *please* create an issue for it using the [template](/issue_template.md).
 
@@ -149,17 +150,8 @@ _Is hungry for linked data so she can serve you up search traffic_
 ### 'Searcher'
 _Is a developer with a problem, she is looking for something to help solve it._
 
-### 'Producer'
-_Has a product or products that incorporates some free/open source dependencies. She needs to ensure the product(s) are well maintained, free of vulnerabilities and licence compatible._
-
-### 'Maintainer'
-_Is a developer with a successful free/open source project. She's looking to understand more about those who use her project, attract more contributors and manage their contributions well._
-
 ### 'Extender'
 _Has her own ideas. She wants access to the raw data so that she can mash up her own service and offer it to the world._
-
-### 'Overlord'
-_Has a vast empire of people, products and projects. Some of which she publishes as open source, some are proprietary. She wants to ensure that her policies regarding the use of dependencies are adhered to and that her team are as efficient as possible._
 
 ## Workflow
 In general we use [GitHub](https://help.github.com/) and [Git](https://git-scm.com/docs/gittutorial) to support our workflow. If you are unfamiliar with those tools then you should check them out until you feel you have a basic understanding of GitHub and a working understanding of Git. Specifically you should understand how forking, branching, committing, PRing and merging works.
@@ -198,5 +190,6 @@ We appreciate that it may be difficult to offer constructive criticism, but it i
 
 #### Merging
 As we keep the `master` branch in a permanent state of 'deployment ready' once-merged your contribution will be live on the next deployment.
+
 #### Deploying
 Any member of the [deployers](https://github.com/orgs/librariesio/teams/deployers) team are able to redeploy the site. If you require a deployment then you might find one of them in our `#general` [chat channel on Slack](slack.libraries.io).

--- a/data.md
+++ b/data.md
@@ -9,7 +9,9 @@ Data gathered by Libraries.io is avaialble for download on [Zenodo](https://zeno
 
 ### Acccessing Libraries' Data Programatically
 
-Libraries'[API](https://libraries.io/api) provides up-to-date information for a project, repository or user. Data will soon be avaialble via Google BigQuery as apart of their public datasets programme. 
+Libraries'[API](https://libraries.io/api) provides up-to-date information for a project, repository or user. 
+
+Data is also avaialble via Google BigQuery as apart of their (public datasets programme)[https://console.cloud.google.com/launcher/details/libraries-io/librariesio]
 
 ### Licence
 
@@ -18,9 +20,3 @@ All data gathered by Libraries.io is provided under a Creative Commons, Attribut
 ### Requests
 
 Our strategy is to gather and share information about open source software to create a stronger ecosystem and help developers make more informated decisions about the software they use. If there's some data that Libraries.io does not currently collect that you would like to use in your research, application or service please [create a ticket for it](https://github.com/librariesio/metrics/issues/new). 
-
-
-
-
-
-

--- a/index.md
+++ b/index.md
@@ -20,7 +20,7 @@ We do this by tackling three problems:
 Libraries.io is the place that we attempt to solve the discovery problem for users, we solve the other two at our parent company [Tidelift](https://tidelift.com). If you'd like to know why we think this is the right approach then check out [our strategy](/strategy.md).
 
 ### Who are Tidelift?
-In October 2017 Libraries.io maintainers Andrew Nesbitt and Benjamin Nickolls decided to join a new company focussed on building a sustainable future for open source software. Tidelift launched to the public in February 2017 and continue to support Libraries.io as part of their core philosophy and strategy.  
+In October 2017 Libraries.io maintainers Andrew Nesbitt and Benjamin Nickolls decided to join a new company focussed on building a sustainable future for open source software. Tidelift launched to the public in February 2018 and continue to support Libraries.io as part of their core philosophy and strategy.  
 
 ## Who is Libraries.io For?
 

--- a/index.md
+++ b/index.md
@@ -15,28 +15,29 @@ We do this by tackling three problems:
 
 * Discovery: _Helping developers make faster, more informed decisions about the software that they use._
 * Maintainability: _Helping maintainers understand more about the software they depend upon and the consumers of their software._
-* Sustainability: _Supporting undervalued software by highlighting shortfalls in contribution and funneling support to them._
+* Sustainability: _Supporting undervalued software by providing a scalable and sustainable revenue for maintainers_
 
-If you'd like to know why we think this is the right approach then check out [our strategy](/strategy.md).
+Libraries.io is the place that we attempt to solve the discovery problem for users, we solve the other two at our parent company [Tidelift](https://tidelift.com). If you'd like to know why we think this is the right approach then check out [our strategy](/strategy.md).
+
+### Who are Tidelift?
+In October 2016 Libraries.io maintainers Andrew Nesbitt and Benjamin Nickolls decided to join a new company focussed on building a sustainable future for open source software. Tidelift launched to the public in February 2017 and continue to support Libraries.io as part of their core philosophy and strategy.  
 
 ## Who is Libraries.io For?
 
 Libraries.io currently caters for the needs of three groups:
 
-* Google: is hungry for your linked datas so she can serve you up search traffic
+* Google: is hungry for your linked datas so she can serve you up search traffic.
 * Searcher: is a developer with a problem, she is looking for something to help solve it.
-* Maintainer: has a project that is used within and/or incorporates open dependencies. She needs to ensure her project(s) are working as expected for users.
 * Extender: has her own ideas. She wants access to the raw data so that she can mash up her own service and offer it to the world.
 
-
-These groups have been expanded into [personas](/personas.md) for contributors to reference.
+These groups have been expanded into [personas](/personas.md) for contributors to reference in their work.
 
 ## How Does Libraries.io Work?
 Libraries.io collects data about software and the frameworks, plugins and tools they depend upon which we collectively call libraries.
 
 Everything in Libraries.io begins with [package managers](/packagemanagers.md), on a regular basis background tasks find new or updated libraries from each of those packages managers. Each library is stored as a project alongside any data we can gleam from the package manager. If the package manager provides a link to a hosted revision control service like GitHub then Libraries.io fetches yet more data from there.
 
-Using the data collected we then calculate the [SourceRank](/overview#sourcerank), this value is used to index the project in search results. Next we highlight any issues regarding updates, deprecated versions, yanked or deleted libraries, license incompatibilities etc. to maintainers who depend on a given library. Finally we highlight undervalued and under-supported libraries, guiding maintainers toward projects that they could contribute to that would have a direct benefit on their own work.
+Using the data collected we then calculate the [SourceRank](/overview#sourcerank), this value is used to index the project in search results. Next we highlight any issues regarding updates, deprecated versions, yanked or deleted libraries, license incompatibilities etc.
 
 If you'd like an overview of the project, including a description of each of the repositories in the Libraries.io organisation and how they work together then check out our [overview](/overview.md).
 

--- a/index.md
+++ b/index.md
@@ -20,7 +20,7 @@ We do this by tackling three problems:
 Libraries.io is the place that we attempt to solve the discovery problem for users, we solve the other two at our parent company [Tidelift](https://tidelift.com). If you'd like to know why we think this is the right approach then check out [our strategy](/strategy.md).
 
 ### Who are Tidelift?
-In October 2016 Libraries.io maintainers Andrew Nesbitt and Benjamin Nickolls decided to join a new company focussed on building a sustainable future for open source software. Tidelift launched to the public in February 2017 and continue to support Libraries.io as part of their core philosophy and strategy.  
+In October 2017 Libraries.io maintainers Andrew Nesbitt and Benjamin Nickolls decided to join a new company focussed on building a sustainable future for open source software. Tidelift launched to the public in February 2017 and continue to support Libraries.io as part of their core philosophy and strategy.  
 
 ## Who is Libraries.io For?
 

--- a/labelling.md
+++ b/labelling.md
@@ -1,5 +1,5 @@
 ## Labelling
-Labelling is a key part of our workflow. We label issues by size, type or skills needed and drive parts of our process using them. Specifically we label tickets that are ideal for first-time contributors or those that are part of our funded commitments.
+Labelling is a key part of our workflow. We label issues by size, type or skills needed and drive parts of our process using them. We pecifically we label tickets that are ideal for first-time contributors.
 
 ### Size
 In the following *day* and *week* mean 'working approximately 7.5 hours per day, five days a week'. That is not to say any contributor is expected to work full-time on the project, but it should provide a truer sense of scale.
@@ -27,10 +27,6 @@ Projects typically indicate the type of issue, but we would like to be more expl
 
 ### First-time Contributors
 * `first-pr` will be used for any ticket ideal for a first-time contributor. These tickets will require minimal understanding of Libraries.io's strategy, architecture and minimal work to install a environment from which to work.
-
-### Funder Commitments
-
-* `funder-commitment` indicates that the ticket is considered directly attributable to one of the [core team's](/coreteam.md) goals for which they receive financial support. You should discuss these issues with members of the core team before proceeding to work on it.
 
 ### Process
 

--- a/personas.md
+++ b/personas.md
@@ -30,31 +30,6 @@ Ada is a senior software developer, four years out of her computer science degre
 
 Ada uses Libraries.io to vet libraries she might want to use on a current or future project. Sometimes she hears about a project from a friend, reads about it on hackernews or sees talk about it at a conference. She's thinks it might come in handy but wants to know a little more: is the library is reliable, actively developed, is there good documentation and a community to support her if she comes unstuck? 
 
-### Maintainer (Belinda)
-_A developer maitnianing a successful FOSS project. She's looking to understand more about those who use her project, attract more contributors and manage their contributions well._
-
-- Age: 28
-- Education: MSc 
-- Lives: Austin
-- Works: Large Technology Company
-- Role: Developer
-- Likes: Skiing, Hiking, Craft Beers 
-
-#### Common Tasks
-- Check project for updates in dependencies
-- Check content of dependency updates (breaking changes, security advisories, licence changes, new dependencies, new transitive dependencies)
-- Check PRs on project
-- Check issues on project
-- Make decisions on project direction (new features, deprecated features etc)
-- Build updates into project (dependencies, new code, documentation etc)
-- Publish new versions
- 
-Charlie works at a large technology company. She works there company because the company allows her to work one day a week on open source projects. For three years Charlie has been a contributor to Pipe, an ORM library. Pipe has a *very* active community of users posting questions, ticketing bugs and feature requests and — whenever a release is shipped — complaints. Charlie suspects Pipe is used by housands of developers but there are only three other people contributing to the project actively. Between them they struggle between work and family to maintain the project. 
-
-Charlie uses Libraries.io to get more information about her project. Who's using it? What kind of applications is it used within? Which versions are they using? How is it deployed? What features are more commonly used? She uses this information to inform the project's roadmap: to prioritise new features and decide which features can be removed, to focus documentation and support processes.
-
-Charlie also uses Libraries.io to keep her project up to date. The project has 68 dependencies which she needs to monitor for vulnerability notices and patches, for version updates — inc. anything that might break anything in her own project — and for dependencies that have been abondoned or deprecated, in which case she needs to find an alterative library to use. 
-
 ### Researcher/Extender (Charlie)
 _has her own ideas. She wants access to the raw data so that she can mash up her own service and offer it to the world._
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,14 +1,27 @@
 ## Road Map
 
-### 2017 Funded Commitments
+We will keep this document updated periodically. Please check our [issue tracker](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Alibrariesio) for up to date information. 
 
-Libraries.io is a project of Brave New Software. The project is supported by the following organisations until 1st January 2018:
+### 2018 Commitments
+As part of Tidelift, the goals for Libraries.io become more focussed on solving discovery issues for our users. Our priorities for 2018 are:
+
+- Redesigning Libraries.io to provide a more didscovery-focussed user experience,
+- Adding time-series data to packages indexed by Libraries.io
+- Expanding and improving our project quality metrics and indicators (known as Sourcerank),
+- Improving our search facilities to include langauge, problem and domain-specific results,
+- Federating our search and data facilities to users through our API,
+- Continuing to support researchers through open access to data gathered by Libraries.io
+
+This alongside our ever-present target to keep expanding the breadth of data gathered by Libraries.io and offering it to the world as a utility service provider. 
+
+### 2017 Funded Commitments
+For much of 2017 Libraries.io was a project of Brave New Software. The project was supported by the following organisations until 1st January 2018:
 
 * [Brave New Software](http://www.bravenewsoftware.org/)
 * [The Alfred P. Sloan Foundation](https://sloan.org/programs/digital-technology)
 * [The Ford Foundation](https://www.fordfoundation.org/work/challenging-inequality/internet-freedom/)
 
-The [supporters repository](https://github.com/librariesio/supporters/issues) contains details of our commitments to our supporters throughout 2017. The main technical goals are:
+The [supporters repository](https://github.com/librariesio/supporters/issues) contains details of our commitments to our supporters throughout 2017. The main technical goals were:
 
 - Adding support for projects hosted on GitLab and BitBucket
 - Creating parity among the supported package managers
@@ -16,7 +29,7 @@ The [supporters repository](https://github.com/librariesio/supporters/issues) co
 - Releasing metric and dependency graph information 
 - Adding external metrics in Libraries.io meta-data
 
-There are also a number of non, developer centered goals. Mainly these are about raising demand for and usage of Libraries.io as a service and as a source of data.
+There were also a number of non, developer centered goals. Mainly these are about raising demand for and usage of Libraries.io as a service and as a source of data.
 
 ### 2017 Additional Goals
 
@@ -26,16 +39,3 @@ In addition to our funded commitments in 2017 we will prioritise:
 - Adding more guidance for contributors
 - Improving technical documentation
 - Publishing our mission, strategy and philosophy
-
-### 2018 Goals
-
-We have a number of ideas that we are interested in pursuing in 2018:
-
-- Monitoring system-level dependencies
-- Bridging from application to system-level dependencies
-- Federating search facilities to multiple providers
-- Improvements to [sourcerank](/overview#sourcerank) 
-- Gathering and sharing more metrics
-- Identifying individual contributors with rights to publish updates
-
-We will keep this document updated periodically. Please check our [issue tracker](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Alibrariesio) for more information. 

--- a/strategy.md
+++ b/strategy.md
@@ -29,6 +29,6 @@ _Supporting undervalued software by createing a new, scalable and sustainable st
 Free and open source software has grown exponentially over the last ten years. And we're indebted to the creators whos work we build applications, services and businesses on top of. But too frequently the maintainers of these projects work individually or in small groups on projects in their spare time with little to no direct support. We want to support maintainers with a new, scalable, sustainable source of revenue so that they can choose to work on open source project rather than subsidising their passion. 
 
 ### Who are Tidelift?
-In October 2016 Libraries.io maintainers Andrew Nesbitt and Benjamin Nickolls decided to join a new company focussed on building a sustainable future for open source software. Tidelift launched to the public in February 2017 and continue to support Libraries.io as part of their core philosophy and strategy. 
+In October 2017 Libraries.io maintainers Andrew Nesbitt and Benjamin Nickolls decided to join a new company focussed on building a sustainable future for open source software. Tidelift launched to the public in February 2017 and continue to support Libraries.io as part of their core philosophy and strategy. 
 
 At Tidelift we focus on solving the problems aassociated with the maintainablity and sustianability parts of this strategy. Libraries.io is _solely_ concerned with solving the issues around discovery of open source software, directly and through partners using our services and data. 

--- a/strategy.md
+++ b/strategy.md
@@ -1,7 +1,7 @@
 ## Strategy
 *Our mission is to raise the quality of all software.*
 
-We will do this by raising the quality and frequency of contributions to free and open source software; the services, frameworks, plugins and tools we collectively refer to as *libraries*. Libraries are published freely under a copyleft license by *maintainers*, maintainers work with *contributors* to develop their projects which are used by *consumers*. Consumers utilise libraries in their own software, for which they may become a contributor or maintainer in the future.
+We will do this by raising the quality and frequency of contributions to free and open source software; the services, frameworks, plugins and tools we collectively refer to as *libraries*. Libraries are published freely under a copyleft license by *maintainers*, maintainers work with *contributors* to develop their projects which are used by *users*. Users utilise libraries in their own software, for which they may become a contributor or maintainer in the future.
 
 Specifically we tackle three distinct problems:
 
@@ -24,11 +24,11 @@ Similarly we can help maintainers by reflecting the state of the ecosystem back 
 By building tools and by offering them to those working on free and open source software without charge, we will ensure that maintainers and consumers get maximum value from the ecosystem. Consumers will be better equipped to see the value they extract from their dependencies. With this knowledge and a little time saved they might consider contributing back and, guided by their self-interest, may choose to support the projects that support them...
 
 ### Sustainability
-_Supporting undervalued software by highlighting shortfalls in contribution and funneling support to them._
+_Supporting undervalued software by createing a new, scalable and sustainable stream of income for maintianers._
 
-The free and open source ecosystem has grown almost exponentially over the last ten years. We see the same patterns in this system as we see in nature. Projects rise and fall in popularity, sometimes making way for others. In doing so they leave a legacy, a legacy that can become a risk for us all. Who's supporting these projects?
+Free and open source software has grown exponentially over the last ten years. And we're indebted to the creators whos work we build applications, services and businesses on top of. But too frequently the maintainers of these projects work individually or in small groups on projects in their spare time with little to no direct support. We want to support maintainers with a new, scalable, sustainable source of revenue so that they can choose to work on open source project rather than subsidising their passion. 
 
-By highlighting libraries that are undervalued and under-supported, to those who will directly benefit by contributing, we can increase the number of contributors to these projects. Our hope is that by focusing search and by creating tools to help maintainers we can turbo-charge contributors and contributions.
+### Who are Tidelift?
+In October 2016 Libraries.io maintainers Andrew Nesbitt and Benjamin Nickolls decided to join a new company focussed on building a sustainable future for open source software. Tidelift launched to the public in February 2017 and continue to support Libraries.io as part of their core philosophy and strategy. 
 
-## What We Won't Do
-We do not believe that profiling any one individual will benefit the ecosystem. People predominantly commit their time to free and open source software on a voluntary basis. With that in mind everyone who does so should be considered, regarded and thanked equally.
+At Tidelift we focus on solving the problems aassociated with the maintainablity and sustianability parts of this strategy. Libraries.io is _solely_ concerned with solving the issues around discovery of open source software, directly and through partners using our services and data. 

--- a/strategy.md
+++ b/strategy.md
@@ -29,6 +29,6 @@ _Supporting undervalued software by createing a new, scalable and sustainable st
 Free and open source software has grown exponentially over the last ten years. And we're indebted to the creators whos work we build applications, services and businesses on top of. But too frequently the maintainers of these projects work individually or in small groups on projects in their spare time with little to no direct support. We want to support maintainers with a new, scalable, sustainable source of revenue so that they can choose to work on open source project rather than subsidising their passion. 
 
 ### Who are Tidelift?
-In October 2017 Libraries.io maintainers Andrew Nesbitt and Benjamin Nickolls decided to join a new company focussed on building a sustainable future for open source software. Tidelift launched to the public in February 2017 and continue to support Libraries.io as part of their core philosophy and strategy. 
+In October 2017 Libraries.io maintainers Andrew Nesbitt and Benjamin Nickolls decided to join a new company focussed on building a sustainable future for open source software. Tidelift launched to the public in February 2018 and continue to support Libraries.io as part of their core philosophy and strategy. 
 
 At Tidelift we focus on solving the problems aassociated with the maintainablity and sustianability parts of this strategy. Libraries.io is _solely_ concerned with solving the issues around discovery of open source software, directly and through partners using our services and data. 


### PR DESCRIPTION
* Updated documentation to make it clearer that Libraries.io is focussing on discovery over maintenance and sustainability.
* Adds a description about who Tidelift are and context around the maintainers joining the team there.
* Adds a new roadmap for 2018 which needs reviewing specifically

Following this we'll need to re-roll out updates to the GH contributors.md template across all repos as I've removed a notice about funded commitments. 

Closes #52 